### PR TITLE
update formats of DATS for harmonization

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -38,7 +38,7 @@
 	"distributions": [
 	        {
 			"formats": [
-				".GFF",
+				"GFF",
 				"FASTA"
             		],
 			"size" : 2.8,


### PR DESCRIPTION
This is step one of the DATS harmonization process happening for CONP-PCNO/conp-dataset#454.

.GFF has been replaced by GFF in the DATS file.